### PR TITLE
SSCS-4614 - Do not fall over when there are no appellant subscriptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ bintray {
 dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: '3.0.1'
     compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '5.0.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.125-rc2'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.125'
     compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '4.0.1'
 
     compile group: 'org.springframework', name: 'spring-context-support', version: '5.1.1.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ bintray {
 dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: '3.0.1'
     compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '5.0.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.123'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.125-rc2'
     compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '4.0.1'
 
     compile group: 'org.springframework', name: 'spring-context-support', version: '5.1.1.RELEASE'

--- a/src/main/resources/templates/appellant_appeal_template.html
+++ b/src/main/resources/templates/appellant_appeal_template.html
@@ -415,16 +415,30 @@
     <dl class="govuk-check-your-answers">
         <div>
             <dt class="cya-question">Receive text message reminders</dt>
-            <dd class="cya-answer">{{ PdfWrapper.sscsCaseData.subscriptions.appellantSubscription.wantSmsNotifications }}</dd>
+            <dd class="cya-answer">
+                {% if PdfWrapper.sscsCaseData.subscriptions.appointeeSubscription is defined %}
+                    {{ PdfWrapper.sscsCaseData.subscriptions.appointeeSubscription.wantSmsNotifications }}
+                {% else %}
+                    {{ PdfWrapper.sscsCaseData.subscriptions.appellantSubscription.wantSmsNotifications }}
+                {% endif %}
+            </dd>
         </div>
 
         <div>
             <dt class="cya-question">Mobile number</dt>
             <dd class="cya-answer">
-                {% if PdfWrapper.sscsCaseData.subscriptions.appellantSubscription.wantSmsNotifications == 'Yes'  %}
-                {{ PdfWrapper.sscsCaseData.subscriptions.appellantSubscription.mobile }}
+                {% if PdfWrapper.sscsCaseData.subscriptions.appointeeSubscription is defined %}
+                    {% if PdfWrapper.sscsCaseData.subscriptions.appointeeSubscription.wantSmsNotifications == 'Yes'  %}
+                    {{ PdfWrapper.sscsCaseData.subscriptions.appointeeSubscription.mobile }}
+                    {% else %}
+                    Not Applicable
+                    {% endif %}
                 {% else %}
-                Not Applicable
+                    {% if PdfWrapper.sscsCaseData.subscriptions.appellantSubscription.wantSmsNotifications == 'Yes'  %}
+                    {{ PdfWrapper.sscsCaseData.subscriptions.appellantSubscription.mobile }}
+                    {% else %}
+                    Not Applicable
+                    {% endif %}
                 {% endif %}
             </dd>
         </div>


### PR DESCRIPTION
Jira : SSCS-4614 and SSCS-4547 

Use the appointee subscription instead of the appellant subscription when there is an appointee on an appeal.