### PR TITLE
Add citizen role when uploading documents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok:1.18.8'
 
+    testCompileOnly 'org.projectlombok:lombok:1.18.6'
     testCompile group: 'junit', name: 'junit', version: 4.12
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.28.2'
     testCompile 'pl.pragmatists:JUnitParams:1.1.1'

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/EvidenceManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/EvidenceManagementService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.service;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
+import uk.gov.hmcts.reform.document.domain.Classification;
 import uk.gov.hmcts.reform.document.domain.Document;
 import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.sscs.document.EvidenceDownloadClientApi;
@@ -48,7 +50,8 @@ public class EvidenceManagementService {
 
         try {
             return documentUploadClientApi
-                .upload(S2S_TOKEN, serviceAuthorization, userId, files);
+                .upload(S2S_TOKEN, serviceAuthorization, userId, Arrays.asList("caseworker", "citizen"),
+                    Classification.RESTRICTED, files);
         } catch (HttpClientErrorException httpClientErrorException) {
             log.error("Doc Store service failed to upload documents...", httpClientErrorException);
             if (null != files) {
@@ -66,15 +69,15 @@ public class EvidenceManagementService {
                 S2S_TOKEN,
                 serviceAuthorization,
                 userId,
-                    "caseworker",
+                "caseworker",
                 documentSelf.getPath().replaceFirst("/", "")
             );
 
-            ResponseEntity<Resource> responseEntity =  evidenceDownloadClientApi.downloadBinary(
+            ResponseEntity<Resource> responseEntity = evidenceDownloadClientApi.downloadBinary(
                 S2S_TOKEN,
                 serviceAuthorization,
                 userId,
-                    "caseworker",
+                "caseworker",
                 URI.create(documentMetadata.links.binary.href).getPath().replaceFirst("/", "")
             );
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/EvidenceManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/EvidenceManagementServiceTest.java
@@ -61,13 +61,13 @@ public class EvidenceManagementServiceTest {
         UploadResponse expectedUploadResponse = mock(UploadResponse.class);
 
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
-        when(documentUploadClientApi.upload(any(), eq(SERVICE_AUTHORIZATION), anyString(), eq(files)))
+        when(documentUploadClientApi.upload(any(), eq(SERVICE_AUTHORIZATION), any(), any(), any(), eq(files)))
                 .thenReturn(expectedUploadResponse);
 
         UploadResponse actualUploadedResponse = evidenceManagementService.upload(files, SSCS_USER);
 
         verify(documentUploadClientApi, times(1))
-                .upload(any(), eq(SERVICE_AUTHORIZATION), anyString(), eq(files));
+                .upload(any(), eq(SERVICE_AUTHORIZATION), any(), any(), any(), eq(files));
 
         assertEquals(actualUploadedResponse, expectedUploadResponse);
     }
@@ -77,7 +77,7 @@ public class EvidenceManagementServiceTest {
         List<MultipartFile> files = mockMultipartFiles();
 
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTHORIZATION);
-        when(documentUploadClientApi.upload(any(), eq(SERVICE_AUTHORIZATION), anyString(), eq(files)))
+        when(documentUploadClientApi.upload(any(), eq(SERVICE_AUTHORIZATION), any(), any(), any(), eq(files)))
                 .thenThrow(new HttpClientErrorException(HttpStatus.UNPROCESSABLE_ENTITY));
 
         evidenceManagementService.upload(files, SSCS_USER);


### PR DESCRIPTION
Because this way citizens can update drafts with those documents in
CCD.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-5969