### PR TITLE
SSCS-5227 Issue further evidence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ plugins {
     id 'maven'
 }
 
+jacoco {
+    toolVersion = "0.8.2"
+}
+
 def buildNumber = System.getenv("TRAVIS_BRANCH") ?: "DEV-SNAPSHOT"
 
 group 'uk.gov.hmcts.reform'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip

--- a/src/main/java/uk/gov/hmcts/reform/sscs/docmosis/config/PdfDocumentConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/docmosis/config/PdfDocumentConfig.java
@@ -1,14 +1,15 @@
 package uk.gov.hmcts.reform.sscs.docmosis.config;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Configuration;
 
-@Data
-@Component
+@Configuration
 @ConfigurationProperties(prefix = "document.pdf")
+@Getter
+@Setter
 public class PdfDocumentConfig {
-
     private String hmctsImgKey;
     private String hmctsImgVal;
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/docmosis/service/DocmosisPdfGenerationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/docmosis/service/DocmosisPdfGenerationService.java
@@ -6,7 +6,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.DocumentHolder;
@@ -16,10 +15,8 @@ import uk.gov.hmcts.reform.sscs.exception.PdfGenerationException;
 @Slf4j
 public class DocmosisPdfGenerationService implements PdfGenerationService {
 
-    @Value("${service.pdf-service.uri}")
     private String pdfServiceEndpoint;
 
-    @Value("${service.pdf-service.accessKey}")
     private String pdfServiceAccessKey;
 
     private RestTemplate restTemplate;
@@ -33,10 +30,6 @@ public class DocmosisPdfGenerationService implements PdfGenerationService {
         this.pdfServiceEndpoint = pdfServiceEndpoint;
         this.pdfServiceAccessKey = pdfServiceAccessKey;
         this.restTemplate = restTemplate;
-    }
-
-    public DocmosisPdfGenerationService() {
-        this.restTemplate = new RestTemplate();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/docmosis/service/DocmosisPdfGenerationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/docmosis/service/DocmosisPdfGenerationService.java
@@ -6,6 +6,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.sscs.docmosis.domain.DocumentHolder;
@@ -15,8 +16,10 @@ import uk.gov.hmcts.reform.sscs.exception.PdfGenerationException;
 @Slf4j
 public class DocmosisPdfGenerationService implements PdfGenerationService {
 
+    @Value("${service.pdf-service.uri}")
     private String pdfServiceEndpoint;
 
+    @Value("${service.pdf-service.accessKey}")
     private String pdfServiceAccessKey;
 
     private RestTemplate restTemplate;
@@ -30,6 +33,10 @@ public class DocmosisPdfGenerationService implements PdfGenerationService {
         this.pdfServiceEndpoint = pdfServiceEndpoint;
         this.pdfServiceAccessKey = pdfServiceAccessKey;
         this.restTemplate = restTemplate;
+    }
+
+    public DocmosisPdfGenerationService() {
+        this.restTemplate = new RestTemplate();
     }
 
     @Override


### PR DESCRIPTION
PdfDocumentConfig is a configuration property class so I add the correct
annotations

DocmosisPdfGeneration service can easily inject the properties that
it needs to work. Therefore, I overload the constructor and inject values

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
