### PR TITLE
find case data before updating it.

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/CcdNotificationsPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/CcdNotificationsPdfService.java
@@ -36,7 +36,7 @@ public class CcdNotificationsPdfService {
     private IdamService idamService;
 
 
-    public SscsCaseData mergeCorrespondenceIntoCcd(SscsCaseData sscsCaseData, Correspondence correspondence) {
+    public SscsCaseData mergeCorrespondenceIntoCcd(Long ccdCaseId, Correspondence correspondence) {
         Map<String, Object> placeholders = new HashMap<>();
         placeholders.put("body", correspondence.getValue().getBody());
         placeholders.put("subject", correspondence.getValue().getSubject());
@@ -60,14 +60,17 @@ public class CcdNotificationsPdfService {
                         .build()).build()
         ).collect(Collectors.toList());
 
-        List<Correspondence> existingCorrespondence = sscsCaseData.getCorrespondence() == null ? new ArrayList<>() : sscsCaseData.getCorrespondence();
+        IdamTokens idamTokens = idamService.getIdamTokens();
+        final SscsCaseDetails sscsCaseDetails = ccdService.getByCaseId(ccdCaseId, idamTokens);
+        final SscsCaseData caseData = sscsCaseDetails.getData();
+
+        List<Correspondence> existingCorrespondence = caseData.getCorrespondence() == null ? new ArrayList<>() : caseData.getCorrespondence();
         List<Correspondence> allCorrespondence = new ArrayList<>(existingCorrespondence);
         allCorrespondence.addAll(correspondences);
         allCorrespondence.sort(Comparator.reverseOrder());
-        sscsCaseData.setCorrespondence(allCorrespondence);
+        caseData.setCorrespondence(allCorrespondence);
 
-        IdamTokens idamTokens = idamService.getIdamTokens();
-        SscsCaseDetails caseDetails = updateCaseInCcd(sscsCaseData, Long.parseLong(sscsCaseData.getCcdCaseId()), "uploadDocument", idamTokens, "added correspondence");
+        SscsCaseDetails caseDetails = updateCaseInCcd(caseData, ccdCaseId, "uploadDocument", idamTokens, "added correspondence");
 
         return caseDetails.getData();
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/CcdNotificationsPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/CcdNotificationsPdfServiceTest.java
@@ -52,6 +52,7 @@ public class CcdNotificationsPdfServiceTest {
                 .build())
                 .build());
 
+        when(ccdService.getByCaseId(eq(Long.valueOf(caseData.getCcdCaseId())), eq(IdamTokens.builder().build()))).thenReturn(SscsCaseDetails.builder().data(caseData).build());
         when(pdfStoreService.store(any(), any(), eq("dl6"))).thenReturn(sscsDocuments);
         when(idamService.getIdamTokens()).thenReturn(IdamTokens.builder().build());
         when(ccdService.updateCase(any(), any(), any(), any(), any(), any())).thenReturn(SscsCaseDetails.builder().data(caseData).build());
@@ -72,7 +73,7 @@ public class CcdNotificationsPdfServiceTest {
                         .correspondenceType(CorrespondenceType.Email)
                         .build()).build();
 
-        service.mergeCorrespondenceIntoCcd(caseData, correspondence);
+        service.mergeCorrespondenceIntoCcd(Long.valueOf(caseData.getCcdCaseId()), correspondence);
         verify(pdfServiceClient).generateFromHtml(any(), any());
         verify(pdfStoreService).store(any(), eq("event 20 04 2019 11:00:00.pdf"), eq(CorrespondenceType.Email.name()));
         verify(ccdService).updateCase(any(), any(), any(), eq("SSCS - upload document event"), eq("added correspondence"), any());
@@ -93,7 +94,6 @@ public class CcdNotificationsPdfServiceTest {
                         .build()).build();
 
 
-        when(ccdService.getByCaseId(eq(caseId), eq(IdamTokens.builder().build()))).thenReturn(SscsCaseDetails.builder().data(caseData).build());
         service.mergeLetterCorrespondenceIntoCcd(bytes, caseId, correspondence);
         verify(pdfStoreService).store(any(), eq("event 20 04 2019 11:00:00.pdf"), eq(CorrespondenceType.Email.name()));
         verify(ccdService).updateCase(any(), any(), any(), eq("SSCS - upload document event"), eq("added correspondence"), any());


### PR DESCRIPTION
Don't rely on notification code giving you an up to date appeal, so find it first before updating the appeal.

Remember to keep this project up to date with sscs-common otherwise this update will lob off data.
