### PR TITLE
Fix the pdf email common build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ targetCompatibility = 11
 repositories {
 
     mavenLocal()
+    mavenCentral()
 
     maven {
         url "https://dl.bintray.com/hmcts/hmcts-maven"
@@ -36,7 +37,6 @@ repositories {
     }
 
     jcenter()
-    mavenCentral()
 
     // jitpack should be last resort
     // see: https://github.com/jitpack/jitpack.io/issues/1939


### PR DESCRIPTION
The build is broken. See the other builds https://github.com/hmcts/sscs-pdf-email-common/pulls.
This is because `https://repo.spring.io/libs-milestone/` requires authentication.
This PR changes the ordering so that mavenCentral() will be pulled in after a check to your local maven repo.
