### PR TITLE
SSCS-8876 - MYA – When uploading documents the evidenceHandled flag is not getting populated

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/CcdPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/CcdPdfService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscs.service;
 
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.UPLOAD_DOCUMENT;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.NO;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -88,6 +89,7 @@ public class CcdPdfService {
         if (fileName.startsWith(APPELLANT_STATEMENT) || fileName.startsWith(REPRESENTATIVE_STATEMENT)) {
             caseData.setScannedDocuments(ListUtils.union(emptyIfNull(caseData.getScannedDocuments()),
                     buildScannedDocListFromSscsDoc(pdfDocuments)));
+            caseData.setEvidenceHandled(NO.getValue());
         } else {
             caseData.setSscsDocument(ListUtils.union(emptyIfNull(caseData.getSscsDocument()),
                     emptyIfNull(pdfDocuments)));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/CcdPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/CcdPdfServiceTest.java
@@ -10,8 +10,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.UPLOAD_DOCUMENT;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.NO;
 import static uk.gov.hmcts.reform.sscs.ccd.util.CaseDataUtils.buildCaseData;
 
 import java.time.LocalDate;
@@ -55,7 +56,7 @@ public class CcdPdfServiceTest {
 
     @Before
     public void setup() {
-        initMocks(this);
+        openMocks(this);
     }
 
     @Test
@@ -109,6 +110,7 @@ public class CcdPdfServiceTest {
                 anyString(), any(IdamTokens.class));
 
         assertThat(caseDataCaptor.getValue().getScannedDocuments().size(), is(expectedNumberOfScannedDocs));
+        assertThat(caseDataCaptor.getValue().getEvidenceHandled(), is(NO.getValue()));
         if (!newStoredSscsDocuments.isEmpty()) {
             String expectedFilename = newStoredSscsDocuments.get(0).getValue().getDocumentFileName();
             Optional<ScannedDocument> scannedDocument = caseDataCaptor.getValue().getScannedDocuments().stream()


### PR DESCRIPTION
SSCS-8876 - MYA – When uploading documents the evidenceHandled flag is not getting populated