### PR TITLE
correct pdf-service-client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ def versions = [
 dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: versions.reformLogging
-    compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '7.0.0'
+    compile group: 'com.github.hmcts', name: 'cmc-pdf-service-client', version: '7.0.0'
 
     implementation 'com.github.hmcts:sscs-common:4.3.6'
 


### PR DESCRIPTION
https://github.com/hmcts/cmc-pdf-service-client now points to https://jitpack.io/#hmcts/cmc-pdf-service-client/7.0.0