### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.4.8'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.8'
 
-    implementation group: 'com.github.hmcts', name: 'java-logging', version: '5.1.9'
+    implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.0.1'
     implementation group: 'com.github.hmcts', name: 'cmc-pdf-service-client', version: '7.0.1'
 
     implementation group: 'com.github.hmcts', name: 'sscs-common', version: '4.26.3'


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.