### PR TITLE
Remove outdated interceptors

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until = "2023-11-01">
+    <suppress until = "2023-12-01">
         <cve>CVE-2023-24998</cve>
         <cve>CVE-2023-20883</cve>
         <cve>CVE-2023-2976</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,32 +7,11 @@
         <cve>CVE-2023-35116</cve>
         <cve>CVE-2023-3635</cve>
         <cve>CVE-2023-3782</cve>
-    </suppress>
-    <suppress until = "2023-11-01">
-        <notes><![CDATA[
-   file name: junit-4.10.jar
-   ]]></notes>
         <cve>CVE-2020-15250</cve>
-        <cve>CVE-2020-15250</cve>
-    </suppress>
-    <suppress until = "2023-11-01">
-        <notes><![CDATA[
-   file name: httpclient-4.5.12.jar
-   ]]></notes>
         <cve>CVE-2020-13956</cve>
-    </suppress>
-    <suppress until = "2023-11-01">
-        <notes><![CDATA[
-   file name: spring-cloud-openfeign-core-3.0.1.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework\.cloud/spring\-cloud\-.*openfeign.*@.*$</packageUrl>
         <cve>CVE-2021-22044</cve>
-    </suppress>
-    <suppress until = "2023-11-01">
-        <notes><![CDATA[
-   file name: json-20220924.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
         <cve>CVE-2022-45688</cve>
+        <cve>CVE-2020-8908</cve>
+        <cve>CVE-2023-5072</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/sscs/docmosis/config/HttpConnectionConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/docmosis/config/HttpConnectionConfiguration.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.sscs.docmosis.config;
 
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -15,8 +13,6 @@ import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.hmcts.reform.logging.httpcomponents.OutboundRequestIdSettingInterceptor;
-import uk.gov.hmcts.reform.logging.httpcomponents.OutboundRequestLoggingInterceptor;
 
 @Configuration
 @ConditionalOnProperty("http.connect.timeout")
@@ -53,9 +49,6 @@ public class HttpConnectionConfiguration {
         CloseableHttpClient client = HttpClientBuilder
                 .create()
                 .useSystemProperties()
-                .addInterceptorFirst(new OutboundRequestIdSettingInterceptor())
-                .addInterceptorFirst((HttpRequestInterceptor) new OutboundRequestLoggingInterceptor())
-                .addInterceptorLast((HttpResponseInterceptor) new OutboundRequestLoggingInterceptor())
                 .setDefaultRequestConfig(config)
                 .build();
 


### PR DESCRIPTION
### Change description ###
Remove logging interceptors to enable java-logging upgrade to 6.0.1 on projects which have sscs-pdf-email-common as a dependency.

