### PR TITLE
SSCSCI Suppression update

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until = "2024-10-06">
+    <suppress until = "2024-11-06">
         <cve>CVE-2023-35116</cve>
-        <cve>CVE-2023-34034</cve>
+        <cve>CVE-2024-45772</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description

Updated suppression date and added new CVE-2024-45772. This is a transitive dependency via elasticsearch 7.17.11. Latest  available version for elasticsearch is 8.15.2.
